### PR TITLE
Reviving the uol_turtlebot_common package

### DIFF
--- a/uol_turtlebot_common/CMakeLists.txt
+++ b/uol_turtlebot_common/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(uol_cmp3641m)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/uol_turtlebot_common/CMakeLists.txt
+++ b/uol_turtlebot_common/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(uol_cmp3641m)
+project(uol_turtlebot_common)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/uol_turtlebot_common/package.xml
+++ b/uol_turtlebot_common/package.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<package>
+  <name>uol_turtlebot_common</name>
+  <version>0.1.6</version>
+  <description>The uol_turtlebot_common package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="cdondrup@lincoln.ac.uk">cdondrup</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>MIT</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/uol_turtlebot_common</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>map_store</run_depend>
+  <run_depend>turtlebot</run_depend>
+  <run_depend>turtlebot_apps</run_depend>
+  <run_depend>turtlebot_create</run_depend>
+  <run_depend>turtlebot_dashboard</run_depend>
+  <run_depend>turtlebot_interactive_markers</run_depend>
+  <run_depend>turtlebot_msgs</run_depend>
+  <run_depend>turtlebot_rviz_launchers</run_depend>
+  <run_depend>turtlebot_simulator</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <metapackage/> 
+  </export>
+</package>


### PR DESCRIPTION
Installing all the necessary packages to run the actual robot. This makes the custom turtlebot workspace obsolete.
