### PR TITLE
Added custom launch file for all of the turtlebot functionalities and a cmd_vel republisher to uol_turtlebot_common

### DIFF
--- a/uol_turtlebot_common/CMakeLists.txt
+++ b/uol_turtlebot_common/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(uol_turtlebot_common)
 find_package(catkin REQUIRED)
-catkin_metapackage()
+catkin_package()
+
+install(PROGRAMS
+  scripts/republish_cmd_vel.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/uol_turtlebot_common/launch/turtlebot.launch
+++ b/uol_turtlebot_common/launch/turtlebot.launch
@@ -1,0 +1,74 @@
+<launch>
+    <!-- KOBUKI BASE ARGUMENTS -->
+    <arg name="base"             default="$(env TURTLEBOT_BASE)"/>  <!-- create, roomba -->
+    <arg name="battery"          default="$(env TURTLEBOT_BATTERY)"/>  <!-- /proc/acpi/battery/BAT0 in 2.6 or earlier kernels-->
+    <arg name="stacks"           default="$(env TURTLEBOT_STACKS)"/>  <!-- circles, hexagons -->
+    <arg name="3d_sensor"        default="$(env TURTLEBOT_3D_SENSOR)"/>  <!-- kinect, asus_xtion_pro -->
+    <arg name="simulation"       default="$(env TURTLEBOT_SIMULATION)"/>
+    <arg name="serialport"       default="$(env TURTLEBOT_SERIAL_PORT)"/> <!-- /dev/ttyUSB0, /dev/ttyS0 -->
+    <arg name="robot_name"       default="$(env TURTLEBOT_NAME)"/>
+    <arg name="robot_type"       default="$(env TURTLEBOT_TYPE)"/>
+
+    <!-- CAMERA ARGUMENTS -->
+    <arg name="camera"      default="camera"/>
+    <arg name="publish_tf"  default="false"/>
+
+    <!-- Factory-calibrated depth registration -->
+    <arg name="depth_registration"              default="true"/>
+    <arg     if="$(arg depth_registration)" name="depth" value="depth_registered" />
+    <arg unless="$(arg depth_registration)" name="depth" value="depth" />
+
+    <!-- Processing Modules -->
+    <arg name="rgb_processing"                  default="true"/>
+    <arg name="ir_processing"                   default="true"/>
+    <arg name="depth_processing"                default="true"/>
+    <arg name="depth_registered_processing"     default="true"/>
+    <arg name="disparity_processing"            default="true"/>
+    <arg name="disparity_registered_processing" default="true"/>
+    <arg name="scan_processing"                 default="true"/>
+
+    <!-- Worker threads for the nodelet manager -->
+    <arg name="num_worker_threads" default="4" />
+
+    <!-- Laserscan topic -->
+    <arg name="scan_topic" default="scan"/>
+
+    <!-- CMDVEL REPUBLISHER ARGUMENTS -->
+    <arg name="x_lim" default="0.55"/>
+    <arg name="z_lim" default="3.14159265359"/>
+
+    <include file="$(find turtlebot_bringup)/launch/minimal.launch">
+        <arg name="base" value="$(arg base)"/>
+        <arg name="battery" value="$(arg battery)"/>
+        <arg name="stacks" value="$(arg stacks)"/>
+        <arg name="3d_sensor" value="$(arg 3d_sensor)"/>
+        <arg name="simulation" value="$(arg simulation)"/>
+        <arg name="serialport" value="$(arg serialport)"/>
+        <arg name="robot_name" value="$(arg robot_name)"/>
+        <arg name="robot_type" value="$(arg robot_type)"/>
+    </include>
+    <include file="$(find turtlebot_bringup)/launch/3dsensor.launch">
+        <arg name="camera" value="$(arg camera)"/>
+        <arg name="publish_tf" value="$(arg publish_tf)"/>
+        <arg name="depth_registration" value="$(arg depth_registration)"/>
+        <arg name="rgb_processing" value="$(arg rgb_processing)"/>
+        <arg name="ir_processing" value="$(arg ir_processing)"/>
+        <arg name="depth_processing" value="$(arg depth_processing)"/>
+        <arg name="depth_registered_processing" value="$(arg depth_registered_processing)"/>
+        <arg name="disparity_processing" value="$(arg disparity_processing)"/>
+        <arg name="disparity_registered_processing" value="$(arg disparity_registered_processing)"/>
+        <arg name="scan_processing" value="$(arg scan_processing)"/>
+        <arg name="num_worker_threads" value="$(arg num_worker_threads)" />
+        <arg name="scan_topic" value="$(arg scan_topic)"/>
+    </include>
+
+    <node pkg="uol_turtlebot_common" type="republish_cmd_vel.py" name="cmd_vel_republisher">
+        <param name="x_lim" type="double" value="$(arg x_lim)"/>
+        <param name="z_lim" type="double" value="$(arg z_lim)"/>
+    </node>
+
+    <!-- <node pkg="strands_webserver" type="strands_webserver" name="strands_webserver" output="screen">
+        <param name="host_ip" value="$(optenv HOST_IP 127.0.0.1)" />
+    </node> -->
+
+</launch>

--- a/uol_turtlebot_common/package.xml
+++ b/uol_turtlebot_common/package.xml
@@ -40,6 +40,7 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>map_store</run_depend>
   <run_depend>turtlebot</run_depend>
   <run_depend>turtlebot_apps</run_depend>
@@ -53,6 +54,5 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <metapackage/> 
   </export>
 </package>

--- a/uol_turtlebot_common/scripts/republish_cmd_vel.py
+++ b/uol_turtlebot_common/scripts/republish_cmd_vel.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import rospy
+from geometry_msgs.msg import Twist
+from math import pi
+
+class CmdVelRepublisher():
+	"A class to republish cmd_vel information"
+
+	def __init__(self):
+		rospy.init_node('cmd_vel_republisher')
+		self.x_lim = rospy.get_param("~x_lim", 0.55)
+		self.z_lim = rospy.get_param("~z_lim", pi)
+		self.pub = rospy.Publisher('/mobile_base/commands/velocity', Twist) 
+		rospy.Subscriber("/cmd_vel", Twist, self.callback) 
+		rospy.logdebug(rospy.get_name() + " setting up")
+
+	def callback(self,msg): 
+		out = Twist()
+		rospy.logdebug(rospy.get_name() + ": I heard %s" % msg)
+		out.linear.x = msg.linear.x if msg.linear.x <= self.x_lim else self.x_lim
+		out.angular.z = msg.angular.z if msg.angular.z <= self.z_lim else self.z_lim
+		self.pub.publish(out)
+
+if __name__ == '__main__':
+    republisher = CmdVelRepublisher()
+    rospy.spin()


### PR DESCRIPTION
Now the topic `/cmd_vel` publishes to `/mobile_base/commands/velocity` to be a bit more transparent for the students use. The republisher also limits the velocities to 0.55 in x direction and PI around z. These are default values which can be set using the parameters `x_lim` and `z_lim` when running the `turtlebot.launch` file.

The `turtlebot.launch` file now starts the base and the kinect plus the new cmd_vel republisher.
