### PR TITLE
Bumper stop for turtlebot

### DIFF
--- a/uol_turtlebot_common/package.xml
+++ b/uol_turtlebot_common/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.10</version>
   <description>The uol_turtlebot_common package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="cdondrup@lincoln.ac.uk">cdondrup</maintainer>
@@ -40,6 +40,10 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>kobuki_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_srvs</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>map_store</run_depend>
   <run_depend>turtlebot</run_depend>

--- a/uol_turtlebot_common/scripts/republish_cmd_vel.py
+++ b/uol_turtlebot_common/scripts/republish_cmd_vel.py
@@ -3,24 +3,48 @@
 import rospy
 from geometry_msgs.msg import Twist
 from math import pi
+from kobuki_msgs.msg import BumperEvent
+from threading import Thread
 
 class CmdVelRepublisher():
-	"A class to republish cmd_vel information"
+    "A class to republish cmd_vel information"
 
-	def __init__(self):
-		rospy.init_node('cmd_vel_republisher')
-		self.x_lim = rospy.get_param("~x_lim", 0.55)
-		self.z_lim = rospy.get_param("~z_lim", pi)
-		self.pub = rospy.Publisher('/mobile_base/commands/velocity', Twist) 
-		rospy.Subscriber("/cmd_vel", Twist, self.callback) 
-		rospy.logdebug(rospy.get_name() + " setting up")
+    def __init__(self):
+        rospy.init_node('cmd_vel_republisher')
+        self.disabled = False
+        self.thread = None
+        self.x_lim = rospy.get_param("~x_lim", 0.55)
+        self.z_lim = rospy.get_param("~z_lim", pi)
+        self.pub = rospy.Publisher('/mobile_base/commands/velocity', Twist)
+        rospy.Subscriber('/mobile_base/events/bumper', BumperEvent,self.bumper_cb)
+        rospy.Subscriber("/cmd_vel", Twist, self.callback)
+        rospy.logdebug(rospy.get_name() + " setting up")
 
-	def callback(self,msg): 
-		out = Twist()
-		rospy.logdebug(rospy.get_name() + ": I heard %s" % msg)
-		out.linear.x = msg.linear.x if msg.linear.x <= self.x_lim else self.x_lim
-		out.angular.z = msg.angular.z if msg.angular.z <= self.z_lim else self.z_lim
-		self.pub.publish(out)
+    def callback(self,msg):
+        if not self.is_disabled():
+            out = Twist()
+            rospy.logdebug(rospy.get_name() + ": I heard %s" % msg)
+            out.linear.x = msg.linear.x if msg.linear.x <= self.x_lim else self.x_lim
+            out.angular.z = msg.angular.z if msg.angular.z <= self.z_lim else self.z_lim
+            self.pub.publish(out)
+        else:
+            rospy.logwarn("cmd vel republisher disabled")
+
+    def stop(self):
+        while self.is_disabled() and not rospy.is_shutdown():
+            out = Twist()
+            out.linear.x = 0.
+            out.angular.z = 0.
+            self.pub.publish(out)
+            rospy.sleep(0.1)
+
+    def bumper_cb(self, msg):
+        if msg.state:
+            self.disabled = msg.state
+            self.thread = Thread(target=self.stop)
+
+    def is_disabled(self):
+        return self.disabled
 
 if __name__ == '__main__':
     republisher = CmdVelRepublisher()

--- a/uol_turtlebot_common/scripts/republish_cmd_vel.py
+++ b/uol_turtlebot_common/scripts/republish_cmd_vel.py
@@ -3,8 +3,9 @@
 import rospy
 from geometry_msgs.msg import Twist
 from math import pi
-from kobuki_msgs.msg import BumperEvent
+from kobuki_msgs.msg import BumperEvent, Led
 from threading import Thread
+from std_srvs.srv import Empty, EmptyResponse
 
 class CmdVelRepublisher():
     "A class to republish cmd_vel information"
@@ -12,11 +13,15 @@ class CmdVelRepublisher():
     def __init__(self):
         rospy.init_node('cmd_vel_republisher')
         self.disabled = False
-        self.thread = None
+        self.stop_thread = None
+        self.led_thread = None
         self.x_lim = rospy.get_param("~x_lim", 0.55)
         self.z_lim = rospy.get_param("~z_lim", pi)
-        self.pub = rospy.Publisher('/mobile_base/commands/velocity', Twist)
-        rospy.Subscriber('/mobile_base/events/bumper', BumperEvent,self.bumper_cb)
+        self.pub = rospy.Publisher('/mobile_base/commands/velocity', Twist, queue_size=10)
+        self.pub_led1 = rospy.Publisher('/mobile_base/commands/led1', Led, queue_size=10)
+        self.pub_led2 = rospy.Publisher('/mobile_base/commands/led2', Led, queue_size=10)
+        rospy.Service("/reset_bumper_stop", Empty, self.enable)
+        rospy.Subscriber('/mobile_base/events/bumper', BumperEvent, self.bumper_cb)
         rospy.Subscriber("/cmd_vel", Twist, self.callback)
         rospy.logdebug(rospy.get_name() + " setting up")
 
@@ -38,10 +43,33 @@ class CmdVelRepublisher():
             self.pub.publish(out)
             rospy.sleep(0.1)
 
+    def leds(self):
+        while self.is_disabled() and not rospy.is_shutdown():
+            self.pub_led1.publish(Led(value=2))
+            self.pub_led2.publish(Led(value=3))
+            rospy.sleep(0.5)
+            self.pub_led1.publish(Led(value=3))
+            self.pub_led2.publish(Led(value=2))
+            rospy.sleep(0.5)
+
+        self.pub_led1.publish(Led(value=0))
+        self.pub_led2.publish(Led(value=0))
+
     def bumper_cb(self, msg):
-        if msg.state:
+        if not self.is_disabled() and msg.state:
             self.disabled = msg.state
-            self.thread = Thread(target=self.stop)
+            self.stop_thread = Thread(target=self.stop)
+            self.stop_thread.start()
+            self.led_thread = Thread(target=self.leds)
+            self.led_thread.start()
+
+    def enable(self, req):
+        self.disabled = False
+        if self.stop_thread:
+            self.stop_thread.join()
+        if self.led_thread:
+            self.led_thread.join()
+        return EmptyResponse()
 
     def is_disabled(self):
         return self.disabled


### PR DESCRIPTION
When bumper is pressed, 0 velocities are published and message to `/cmd_vel` are ignored. The leds on the back blink yellow and red to visualise a collision. 

Can be reset via aservice call to `/reset_bumper_stop`.

Tested on khan. Requires the two demo robots to be updated before the demo session. At least the uol_turtlebot_common package.
