### PR TITLE
configure fov and no range restriction

### DIFF
--- a/uol_turtlebot_simulator/launch/includes/kobuki.launch.xml
+++ b/uol_turtlebot_simulator/launch/includes/kobuki.launch.xml
@@ -1,0 +1,24 @@
+<launch>
+  <arg name="base"/>
+  <arg name="stacks"/>
+  <arg name="3d_sensor"/>
+  <arg name="fov" default="60"/>
+  
+  <arg name="urdf_file" default="$(find xacro)/xacro.py '$(find uol_turtlebot_simulator)/urdf/$(arg base)_$(arg stacks)_$(arg 3d_sensor).urdf.xacro' fov:=$(arg fov)" />
+  <param name="robot_description" command="$(arg urdf_file)" />
+  
+  <!-- Gazebo model spawner -->
+  <node name="spawn_turtlebot_model" pkg="gazebo_ros" type="spawn_model"
+        args="$(optenv ROBOT_INITIAL_POSE) -unpause -urdf -param robot_description -model mobile_base"/>
+  
+  <!-- Velocity muxer -->
+  <node pkg="nodelet" type="nodelet" name="mobile_base_nodelet_manager" args="manager"/>
+  <node pkg="nodelet" type="nodelet" name="cmd_vel_mux"
+        args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
+    <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml" />
+    <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
+  </node>
+
+  <!-- Bumper/cliff to pointcloud (not working, as it needs sensors/core messages) -->
+  <include file="$(find turtlebot_bringup)/launch/includes/kobuki/bumper2pc.launch.xml"/>
+</launch>

--- a/uol_turtlebot_simulator/launch/maze1.launch
+++ b/uol_turtlebot_simulator/launch/maze1.launch
@@ -1,7 +1,10 @@
 <launch>
 
-  <include file="$(find turtlebot_gazebo)/launch/turtlebot_world.launch">
+  <arg name="fov"       default="60"/>
+
+  <include file="$(find uol_turtlebot_simulator)/launch/turtlebot_world.launch">
     <arg name="world_file" value="$(find uol_turtlebot_simulator)/worlds/maze1.world" />
+    <arg name="fov" value="$(arg fov)" />
   </include>
 
   <!-- <include file="$(find turtlebot_gazebo)/launch/amcl_demo.launch">

--- a/uol_turtlebot_simulator/launch/maze2.launch
+++ b/uol_turtlebot_simulator/launch/maze2.launch
@@ -1,7 +1,10 @@
 <launch>
 
-  <include file="$(find turtlebot_gazebo)/launch/turtlebot_world.launch">
+  <arg name="fov"       default="60"/>
+
+  <include file="$(find uol_turtlebot_simulator)/launch/turtlebot_world.launch">
     <arg name="world_file" value="$(find uol_turtlebot_simulator)/worlds/maze2.world" />
+    <arg name="fov" value="$(arg fov)" />
   </include>
 
   <!-- <include file="$(find turtlebot_gazebo)/launch/amcl_demo.launch">

--- a/uol_turtlebot_simulator/launch/maze3.launch
+++ b/uol_turtlebot_simulator/launch/maze3.launch
@@ -1,7 +1,10 @@
 <launch>
 
-  <include file="$(find turtlebot_gazebo)/launch/turtlebot_world.launch">
+  <arg name="fov"       default="60"/>
+
+  <include file="$(find uol_turtlebot_simulator)/launch/turtlebot_world.launch">
     <arg name="world_file" value="$(find uol_turtlebot_simulator)/worlds/maze3.world" />
+    <arg name="fov" value="$(arg fov)" />
   </include>
 
   <!-- <include file="$(find turtlebot_gazebo)/launch/amcl_demo.launch">

--- a/uol_turtlebot_simulator/launch/simple.launch
+++ b/uol_turtlebot_simulator/launch/simple.launch
@@ -1,7 +1,10 @@
 <launch>
 
-  <include file="$(find turtlebot_gazebo)/launch/turtlebot_world.launch">
+  <arg name="fov"       default="60"/>
+
+  <include file="$(find uol_turtlebot_simulator)/launch/turtlebot_world.launch">
     <arg name="world_file" value="$(find uol_turtlebot_simulator)/worlds/empty_maze.world" />
+    <arg name="fov" value="$(arg fov)" />
   </include>
 
   <!-- <include file="$(find turtlebot_gazebo)/launch/amcl_demo.launch">

--- a/uol_turtlebot_simulator/launch/turtlebot_world.launch
+++ b/uol_turtlebot_simulator/launch/turtlebot_world.launch
@@ -34,6 +34,7 @@
     <param name="scan_height" value="10"/>
     <param name="output_frame_id" value="/camera_depth_frame"/>
     <param name="range_min" value="0.001"/>
+    <param name="range_max" value="100"/>
     <remap from="image" to="/camera/depth/image_raw"/>
     <remap from="scan" to="/scan"/>
   </node>

--- a/uol_turtlebot_simulator/launch/turtlebot_world.launch
+++ b/uol_turtlebot_simulator/launch/turtlebot_world.launch
@@ -1,0 +1,40 @@
+<launch>
+  <arg name="world_file"  default="$(env TURTLEBOT_GAZEBO_WORLD_FILE)"/>
+
+  <arg name="base"      value="$(optenv TURTLEBOT_BASE kobuki)"/> <!-- create, roomba -->
+  <arg name="battery"   value="$(optenv TURTLEBOT_BATTERY /proc/acpi/battery/BAT0)"/>  <!-- /proc/acpi/battery/BAT0 --> 
+  <arg name="gui" default="true"/>
+  <arg name="stacks"    value="$(optenv TURTLEBOT_STACKS hexagons)"/>  <!-- circles, hexagons --> 
+  <arg name="3d_sensor" value="$(optenv TURTLEBOT_3D_SENSOR kinect)"/>  <!-- kinect, asus_xtion_pro --> 
+  <arg name="fov"       default="60"/>
+
+
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="use_sim_time" value="true"/>
+    <arg name="debug" value="false"/>
+    <arg name="gui" value="$(arg gui)" />
+    <arg name="world_name" value="$(arg world_file)"/>
+  </include>
+  
+  <include file="$(find uol_turtlebot_simulator)/launch/includes/kobuki.launch.xml">
+    <arg name="base" value="kobuki"/>
+    <arg name="stacks" value="$(arg stacks)"/>
+    <arg name="3d_sensor" value="kinect"/>
+    <arg name="fov" value="$(arg fov)"/>    
+  </include>
+  
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
+    <param name="publish_frequency" type="double" value="30.0" />
+  </node>
+  
+  <!-- Fake laser -->
+  <node pkg="nodelet" type="nodelet" name="laserscan_nodelet_manager" args="manager"/>
+  <node pkg="nodelet" type="nodelet" name="depthimage_to_laserscan"
+        args="load depthimage_to_laserscan/DepthImageToLaserScanNodelet laserscan_nodelet_manager">
+    <param name="scan_height" value="10"/>
+    <param name="output_frame_id" value="/camera_depth_frame"/>
+    <param name="range_min" value="0.001"/>
+    <remap from="image" to="/camera/depth/image_raw"/>
+    <remap from="scan" to="/scan"/>
+  </node>
+</launch>

--- a/uol_turtlebot_simulator/urdf/kobuki_hexagons_kinect.urdf.xacro
+++ b/uol_turtlebot_simulator/urdf/kobuki_hexagons_kinect.urdf.xacro
@@ -6,7 +6,10 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find uol_turtlebot_simulator)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_common_library.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/urdf/stacks/hexagons.urdf.xacro"/>
+  <xacro:include filename="$(find uol_turtlebot_simulator)/urdf/sensors/kinect.urdf.xacro"/>
   
   <kobuki/>
   <stack_hexagons parent="base_link"/>

--- a/uol_turtlebot_simulator/urdf/sensors/kinect.urdf.xacro
+++ b/uol_turtlebot_simulator/urdf/sensors/kinect.urdf.xacro
@@ -1,97 +1,68 @@
 <?xml version="1.0"?>
 <robot name="sensor_kinect" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find uol_turtlebot_simulator)/urdf/turtlebot_gazebo.urdf.xacro"/>
-  <xacro:include filename="$(find uol_turtlebot_simulator)/urdf/turtlebot_properties.urdf.xacro"/>
+  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_properties.urdf.xacro"/>
   
+  <xacro:property name="kinect_cam_py" value="-0.0125"/>
   <!-- Parameterised in part by the values in turtlebot_properties.urdf.xacro -->
   <xacro:macro name="sensor_kinect" params="parent">
     <joint name="camera_rgb_joint" type="fixed">
-      <origin xyz="${cam_px} ${cam_py} ${cam_pz}" rpy="${cam_or} ${cam_op} ${cam_oy}"/>
+      <origin xyz="${cam_px} ${kinect_cam_py} ${cam_pz}" rpy="${cam_or} ${cam_op} ${cam_oy}"/>
       <parent link="${parent}"/>
       <child link="camera_rgb_frame" />
     </joint>
-    <link name="camera_rgb_frame">
-      <inertial>
-        <mass value="0.001" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001" />
-      </inertial>
-    </link>
+    <link name="camera_rgb_frame"/>
+
     <joint name="camera_rgb_optical_joint" type="fixed">
       <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
       <parent link="camera_rgb_frame" />
       <child link="camera_rgb_optical_frame" />
     </joint>
-    <link name="camera_rgb_optical_frame">
+    <link name="camera_rgb_optical_frame"/>
+
+    <joint name="camera_joint" type="fixed">
+      <origin xyz="-0.031 ${-kinect_cam_py} -0.016" rpy="0 0 0"/>
+      <parent link="camera_rgb_frame"/>
+      <child link="camera_link"/>
+    </joint>  
+      <link name="camera_link">
+      <visual>
+       <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
+        <geometry>
+         <mesh filename="package://turtlebot_description/meshes/sensors/kinect.dae"/>
+        </geometry>
+      </visual>
+  	  <collision>
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+  	    <geometry>
+  	      <box size="0.07271 0.27794 0.073"/>
+  	    </geometry>
+  	  </collision>
       <inertial>
-        <mass value="0.001" />
+        <mass value="0.564" />
         <origin xyz="0 0 0" />
-        <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-                 iyy="0.0001" iyz="0.0"
-                 izz="0.0001" />
+        <inertia ixx="0.003881243" ixy="0.0" ixz="0.0"
+                 iyy="0.000498940" iyz="0.0"
+                 izz="0.003879257" />
       </inertial>
     </link>
 
-  <joint name="camera_joint" type="fixed">
-    <origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>
-    <parent link="camera_rgb_frame"/>
-    <child link="camera_link"/>
-  </joint>  
-    <link name="camera_link">
-    <visual>
-     <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
-      <geometry>
-       <mesh filename="package://uol_turtlebot_simulator/meshes/sensors/kinect.dae"/>
-      </geometry>
-    </visual>
-	  <collision>
-      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
-	    <geometry>
-	      <box size="0.07271 0.27794 0.073"/>
-	    </geometry>
-	  </collision>
-    <inertial>
-      <mass value="0.001" />
-      <origin xyz="0 0 0" />
-      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-               iyy="0.0001" iyz="0.0"
-               izz="0.0001" />
-    </inertial>
-  </link>
-	  
-  <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch 
-       files. However, for Gazebo simulation we need them, so we add them here.
-       (Hence, don't publish them additionally!) -->
+    <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch 
+         files. However, for Gazebo simulation we need them, so we add them here.
+         (Hence, don't publish them additionally!) -->
 	<joint name="camera_depth_joint" type="fixed">
-	  <origin xyz="0 ${2 * -cam_py} 0" rpy="0 0 0" />
+	  <origin xyz="0 ${2 * -kinect_cam_py} 0" rpy="0 0 0" />
 	  <parent link="camera_rgb_frame" />
 	  <child link="camera_depth_frame" />
 	</joint>
-	<link name="camera_depth_frame">
-    <inertial>
-      <mass value="0.001" />
-      <origin xyz="0 0 0" />
-      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-               iyy="0.0001" iyz="0.0"
-               izz="0.0001" />
-    </inertial>
-	</link>
+	<link name="camera_depth_frame"/>
+
 	<joint name="camera_depth_optical_joint" type="fixed">
 	  <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
 	  <parent link="camera_depth_frame" />
 	  <child link="camera_depth_optical_frame" />
 	</joint>
-	<link name="camera_depth_optical_frame">
-    <inertial>
-      <mass value="0.001" />
-      <origin xyz="0 0 0" />
-      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
-               iyy="0.0001" iyz="0.0"
-               izz="0.0001" />
-    </inertial>
-	</link>
+	<link name="camera_depth_optical_frame"/>
 	
 	<!-- Kinect sensor for simulation -->
 	<turtlebot_sim_3dsensor/>

--- a/uol_turtlebot_simulator/urdf/turtlebot_gazebo.urdf.xacro
+++ b/uol_turtlebot_simulator/urdf/turtlebot_gazebo.urdf.xacro
@@ -14,7 +14,7 @@
             <height>480</height>
           </image>
           <clip>
-            <near>0.295</near>
+            <near>0.05</near>
             <far>100.0</far>
           </clip>
         </camera>

--- a/uol_turtlebot_simulator/urdf/turtlebot_gazebo.urdf.xacro
+++ b/uol_turtlebot_simulator/urdf/turtlebot_gazebo.urdf.xacro
@@ -14,7 +14,7 @@
             <height>480</height>
           </image>
           <clip>
-            <near>0.26</near>
+            <near>0.295</near>
             <far>100.0</far>
           </clip>
         </camera>
@@ -34,7 +34,7 @@
           <distortion_k3>0.0</distortion_k3>
           <distortion_t1>0.0</distortion_t1>
           <distortion_t2>0.0</distortion_t2>
-          <pointCloudCutoff>0.26</pointCloudCutoff>
+          <pointCloudCutoff>0.295</pointCloudCutoff>
           <pointCloudCutoffMax>100</pointCloudCutoffMax>
         </plugin>
       </sensor>

--- a/uol_turtlebot_simulator/urdf/turtlebot_gazebo.urdf.xacro
+++ b/uol_turtlebot_simulator/urdf/turtlebot_gazebo.urdf.xacro
@@ -7,15 +7,15 @@
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <camera>
-          <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${$(arg fov)*M_PI/180.0}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
             <height>480</height>
           </image>
           <clip>
-            <near>0.05</near>
-            <far>8.0</far>
+            <near>0.26</near>
+            <far>100.0</far>
           </clip>
         </camera>
         <plugin name="kinect_camera_controller" filename="libgazebo_ros_openni_kinect.so">
@@ -34,8 +34,8 @@
           <distortion_k3>0.0</distortion_k3>
           <distortion_t1>0.0</distortion_t1>
           <distortion_t2>0.0</distortion_t2>
-          <pointCloudCutoff>0.4</pointCloudCutoff>
-          <pointCloudCutoffMax>20</pointCloudCutoffMax>
+          <pointCloudCutoff>0.26</pointCloudCutoff>
+          <pointCloudCutoffMax>100</pointCloudCutoffMax>
         </plugin>
       </sensor>
     </gazebo>


### PR DESCRIPTION
This PR removes the cut-off for depth points and in the laser scan, allowing the robot to see obstacles also right in front of it and up to 100m far away.

It also adds a new parameter `fov`, allowing to change the field of view of the RGBD camera in degrees. The default remains 60 degrees, but each major launch file can now be called like this:

```
roslaunch uol_turtlebot_simulator maze1.launch fov:=160
```

to change the field of view. Valid values are `fov<180` (for obvious reasons that an image plane is assumed)
