### PR TITLE
only use lo interface

### DIFF
--- a/.devcontainer/setup-router.sh
+++ b/.devcontainer/setup-router.sh
@@ -21,7 +21,7 @@ read -r -d '' CYCLONEDDS_URI << EOM
             <Peer address="`hostname`"/>
             <!--<Peer address="[IPV6-address]"/>-->
         </Peers>
-        <ParticipantIndex>auto</ParticipantIndex>
+        <ParticipantIndex>120</ParticipantIndex>
     </Discovery>
         <Internal>
             <Watermarks>
@@ -32,6 +32,18 @@ read -r -d '' CYCLONEDDS_URI << EOM
             <Verbosity>info</Verbosity>
             <OutputFile>stdout</OutputFile>
         </Tracing>
+    </Domain>
+</CycloneDDS>
+EOM
+
+read -r -d '' CYCLONEDDS_URI << EOM
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+    <Domain>
+        <General>
+            <AllowMulticast>false</AllowMulticast>
+            <NetworkInterfaceAddress>127.0.0.1</NetworkInterfaceAddress>
+        </General>
     </Domain>
 </CycloneDDS>
 EOM


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Trying to overcome some DDS challenges to provide only `lo` interface connectivity in the most simple of setups.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Related Issue https://github.com/LCAS/limo_ros2/issues/20

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes._

## [optional] Are there any post deployment tasks we need to perform?
