### PR TITLE
fix base image version

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base_image: lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl
+          - base_image: lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl-1
             ros_distro: humble
             push_image: lcas.lincoln.ac.uk/devcontainer/ros2-teaching
   
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base_image: lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl-arm64
+          - base_image: lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl-arm64-1
             ros_distro: humble
             push_image: lcas.lincoln.ac.uk/devcontainer/ros2-teaching-arm64
   


### PR DESCRIPTION
This pull request includes changes to the base image versions used in the `container-build.yml` workflow file. The updates ensure the correct versions of the base images are used for building the containers.

Updates to base image versions:

* [`.github/workflows/container-build.yml`](diffhunk://#diff-2a66da73436042ba8bf55a760599d9d73b22be874b1d13e02f3f2839263b87a8L49-R49): Updated the base image version for `jammy-humble-cuda12.2-opengl` to `jammy-humble-cuda12.2-opengl-1`.
* [`.github/workflows/container-build.yml`](diffhunk://#diff-2a66da73436042ba8bf55a760599d9d73b22be874b1d13e02f3f2839263b87a8L115-R115): Updated the base image version for `jammy-humble-cuda12.2-opengl-arm64` to `jammy-humble-cuda12.2-opengl-arm64-1`.