### PR TITLE
multiarch

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -13,87 +13,20 @@ on:
 jobs:
   build-docker-image:
     if: github.repository_owner == 'LCAS'
-    runs-on: lcas
+    runs-on: 
+      - lcas
+      - qemu
     strategy:
       fail-fast: false
       matrix:
         include:
-          - base_image: lcas.lincoln.ac.uk/lcas/limo_platform_amd64:1
+          - base_image: lcas.lincoln.ac.uk/lcas/limo_platform:1
             push_image: lcas.lincoln.ac.uk/devcontainer/ros2-teaching
   
     steps:
     - name: Node Js
       uses: actions/setup-node@v4
-      with:
-        node-version: "^16.13.0 || >=18.0.0"
-
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-        submodules: 'recursive'
-
-    - name: What
-      run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-    - name: Docker Login LCAS
-      uses: docker/login-action@v3
-      with:
-        registry: lcas.lincoln.ac.uk
-        username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
-        password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
-
-    - name: Docker meta
-      id: meta_public
-      uses: docker/metadata-action@v5
-      with:
-        # list of Docker images to use as base name for tags
-        images: |
-          ${{ matrix.push_image }}
-          ${{ matrix.push_image }}-amd64
-        # generate Docker tags based on the following events/attributes
-        tags: |
-          type=raw,value=staging
-          type=raw,enable=${{ github.event_name != 'pull_request' }},value=latest
-          type=ref,enable=${{ github.event_name != 'pull_request' }},event=branch
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}        
-
-    - name: Build Public Docker Image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: .devcontainer/Dockerfile
-        platforms: linux/amd64
-        pull: true
-        push: true
-        tags: ${{ steps.meta_public.outputs.tags }}
-        labels: ${{ steps.meta_public.outputs.labels }}
-        target: compiled
-        build-args: |
-            BASE_IMAGE=${{ matrix.base_image }}
-            BRANCH=${{ env.BRANCH }}
-
-
-  build-arm-docker-image:
-    if: github.repository_owner == 'LCAS'
-    runs-on: 
-      - lcas-runc
-      - runc
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - base_image: lcas.lincoln.ac.uk/lcas/limo_platform_arm64:1
-            ros_distro: humble
-            push_image: lcas.lincoln.ac.uk/devcontainer/ros2-teaching-arm64
   
-    steps:
-    - name: Node Js
-      uses: actions/setup-node@v4
-      with:
-        node-version: "^16.13.0 || >=18.0.0"
-
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
@@ -108,20 +41,21 @@ jobs:
         registry: lcas.lincoln.ac.uk
         username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
         password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
-
+ 
+    - name: "image name from repo name"
+      id: docker_image_name
+      run: echo "docker_image=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' |sed 's/[^0-9,a-z,A-Z,=,_,\/]/-/g' >>${GITHUB_OUTPUT}
+  
     - name: Docker meta
       id: meta_public
       uses: docker/metadata-action@v5
       with:
-        flavor: |
-          latest=false
         # list of Docker images to use as base name for tags
         images: |
           ${{ matrix.push_image }}
         # generate Docker tags based on the following events/attributes
         tags: |
           type=raw,value=staging
-          type=raw,enable=${{ github.event_name != 'pull_request' }},value=latest
           type=ref,enable=${{ github.event_name != 'pull_request' }},event=branch
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
@@ -132,13 +66,13 @@ jobs:
       with:
         context: .
         file: .devcontainer/Dockerfile
-        platforms: linux/arm64
-        pull: true
+        platforms: linux/amd64,linux/arm64
         push: true
+        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ steps.docker_image_name.outputs.docker_image }}:latest
+        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ steps.docker_image_name.outputs.docker_image }}:latest,mode=max
         tags: ${{ steps.meta_public.outputs.tags }}
         labels: ${{ steps.meta_public.outputs.labels }}
         target: compiled
         build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             BRANCH=${{ env.BRANCH }}
-          


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/container-build.yml` file to improve the Docker image build process. The key updates involve modifying the build strategy, updating the base image, and optimizing the Docker build and caching process.

Changes to build strategy and platform support:

* Updated the `runs-on` parameter to include both `lcas` and `qemu` runners for enhanced platform support.
* Combined the build steps for both amd64 and arm64 platforms into a single job, simplifying the workflow and ensuring both architectures are built together.

Updates to base image and build arguments:

* Changed the base image from `lcas.lincoln.ac.uk/lcas/limo_platform_amd64:1` to `lcas.lincoln.ac.uk/lcas/limo_platform:1` to use a more generic platform image.

Optimizations to Docker build and caching:

* Added Docker cache configuration to utilize registry-based caching, which can speed up the build process by reusing previously built layers.
* Simplified the Docker meta and build steps by removing redundant configurations and consolidating image tagging and labeling logic.