### PR TITLE
use new limo base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,8 @@
 	"build": {
 		"dockerfile": "./Dockerfile",
 		"args": {
-			// set the base image, add `-arm64` as a suffix if you have an ARM (e.g. Apple Mx) CPU:
-			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/limo_platform_amd64:1"
+			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/limo_platform:2"
 		},
-		// change this to linux/arm64 if you have an ARM (e.g. Apple Mx) CPU:
-		"platform": "linux/amd64",
 		"context": ".."
 	},
 

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base_image: lcas.lincoln.ac.uk/lcas/limo_platform:1
+          - base_image: lcas.lincoln.ac.uk/lcas/limo_platform:2
             push_image: lcas.lincoln.ac.uk/devcontainer/ros2-teaching
   
     steps:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/container-build.yml` file. The change updates the `base_image` version from `1` to `2`.